### PR TITLE
'Get Blank Form' Page Crashing

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -440,7 +440,7 @@ public class FormDownloadList extends ListActivity implements FormListDownloader
                 final View dialogView = factory.inflate(R.layout.server_auth_dialog, null);
 
                 // Get the server, username, and password from the settings
-                SharedPreferences settings =
+                final SharedPreferences settings =
                     PreferenceManager.getDefaultSharedPreferences(getBaseContext());
                 String server =
                     settings.getString(PreferencesActivity.KEY_SERVER_URL,
@@ -474,6 +474,10 @@ public class FormDownloadList extends ListActivity implements FormListDownloader
 
                         WebUtils.addCredentials(username.getText().toString(), password.getText()
                                 .toString(), u.getHost());
+                        SharedPreferences.Editor editor = settings.edit();
+                        editor.putString(PreferencesActivity.KEY_USERNAME, username.getText().toString());
+                        editor.putString(PreferencesActivity.KEY_PASSWORD, password.getText().toString());
+                        editor.commit();
                         downloadFormList();
                     }
                 });

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormDetails.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormDetails.java
@@ -14,7 +14,12 @@
 
 package org.odk.collect.android.logic;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.util.Log;
+
+import org.odk.collect.android.preferences.PreferencesActivity;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -125,5 +130,32 @@ public class FormDetails implements Serializable, Comparator<FormDetails>, Compa
         } else {
             return -1;// lhs is considered less than rhs
         }
+    }
+
+    /**
+     * Determines whether a form should be showing based on whether the 'Show shared forms' preference
+     * is turned on
+     *
+     * @param context
+     * @param curForm
+     * @return
+     */
+    public static boolean formShouldBeShowing(Context context, FormDetails curForm) {
+        SharedPreferences settings =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        boolean showSharedForms = settings.getBoolean(PreferencesActivity.KEY_SHOW_SHARED_FORMS,
+                true);
+
+        if (!showSharedForms) {
+            String username = settings.getString(PreferencesActivity.KEY_USERNAME, null);
+            String user = FormDetails.getOnaUser(curForm);
+
+            if (user == null || username == null || !user.equals(username)) {
+                return false;
+            }
+
+        }
+
+        return true;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -30,6 +30,7 @@ import org.odk.collect.android.preferences.PreferencesActivity;
 import org.odk.collect.android.utilities.DocumentFetchResult;
 import org.odk.collect.android.utilities.WebUtils;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.preference.PreferenceManager;
@@ -209,7 +210,10 @@ public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String
                             R.string.parse_openrosa_formlist_failed, error)));
                     return formList;
                 }
-                formList.put(formId, new FormDetails(formName, downloadUrl, manifestUrl, formId, (version != null) ? version : majorMinorVersion));
+                FormDetails curForm = new FormDetails(formName, downloadUrl, manifestUrl, formId, (version != null) ? version : majorMinorVersion);
+                if (FormDetails.formShouldBeShowing(Collect.getInstance(), curForm)) {
+                    formList.put(formId, curForm);
+                }
             }
         } else {
             // Aggregate 0.9.x mode...
@@ -252,7 +256,10 @@ public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String
                                 R.string.parse_legacy_formlist_failed, error)));
                         return formList;
                     }
-                    formList.put(formName, new FormDetails(formName, downloadUrl, null, formId, null));
+                    FormDetails curForm = new FormDetails(formName, downloadUrl, null, formId, null);
+                    if(FormDetails.formShouldBeShowing(Collect.getInstance(), curForm)) {
+                        formList.put(formName, curForm);
+                    }
 
                     formId = null;
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/WebUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/WebUtils.java
@@ -18,6 +18,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
@@ -613,10 +614,15 @@ public final class WebUtils {
 	public static String downloadUrl(URL url, ArrayList<Header> requestedHeaders)
 			throws IOException {
 		InputStream stream = null;
-		HttpsURLConnection connection = null;
+		HttpURLConnection connection = null;
+		if(url.getProtocol().equalsIgnoreCase("https")) {
+			connection = (HttpsURLConnection) url.openConnection();
+		} else {
+			connection = (HttpURLConnection) url.openConnection();
+		}
+
 		String result = null;
 		try {
-			connection = (HttpsURLConnection) url.openConnection();
 			connection.setReadTimeout(CONNECTION_TIMEOUT);
 			connection.setConnectTimeout(CONNECTION_TIMEOUT);
 
@@ -667,6 +673,7 @@ public final class WebUtils {
 				connection.disconnect();
 			}
 		}
+		Log.d(t, "Result is "+result);
 		return result;
 	}
 


### PR DESCRIPTION
Fixes issue #51 that causes the 'Get Blank Form' page to crash whenever bad credentials are set in the preference page, but good credentials provided while getting blank forms.